### PR TITLE
Disabling a group of events

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,14 @@ let evt = obj.on('event', (value) => {
 evt.off();
 ```
 
+Remove a group of events, that match a regular expression:
+```js
+obj.off(/input:\w+/);
+
+obj.emit('init');
+obj.emit('input:start');    // ignored
+obj.emit('input:end');      // ignored
+```
 
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ Source file: `src/index.js`
 Built versions ES5 (`dist/mr-eventemitter.es5.min.js`) and ES8 (`dist/mr-eventemitter.es8.min.js`):
 
 ```bash
-npm run install
+npm install
 npm run build
 ```

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Provides ability to subscribe and emit events in sync manner. With focus on performance and memory efficiency.",
   "main": "src/index.js",
   "files": [
-      "dist/mr-eventemitter.es5.min.js",
-      "dist/mr-eventemitter.es8.min.js"
+    "dist/mr-eventemitter.es5.min.js",
+    "dist/mr-eventemitter.es8.min.js"
   ],
   "scripts": {
     "closure:es5": "google-closure-compiler --language_in=ECMASCRIPT_2017 --language_out=ECMASCRIPT5_STRICT --compilation_level=SIMPLE_OPTIMIZATIONS --warning_level=VERBOSE --jscomp_off=nonStandardJsDocs --jscomp_off=checkTypes --js src/index.js --js_output_file dist/mr-eventemitter.es5.min.js",
@@ -23,9 +23,9 @@
     "eventemitter"
   ],
   "author": {
-    "name" : "Maksims Mihejevs",
-    "email" : "core@moka.co",
-    "url" : "https://twitter.com/mrmaxm"
+    "name": "Maksims Mihejevs",
+    "email": "core@moka.co",
+    "url": "https://twitter.com/mrmaxm"
   },
   "funding": {
     "type": "individual",

--- a/src/index.js
+++ b/src/index.js
@@ -102,6 +102,14 @@ class EventEmitter {
                 }
             }
             this._events.clear();
+        } else if (name instanceof RegExp) {
+            for (const [eventName, val] of this._events.entries()) {
+                const result = eventName.match(name);
+                if (result) {
+                    const matchedName = result[0];
+                    this.off(matchedName);
+                }
+            }
         } else if (! callback) {
             if (this._events.has(name)) {
                 for(let evt of this._events.get(name)) {


### PR DESCRIPTION
Adds support for regular expressions, in order to be able to unsubscribe from a group of events. Example:
```js
class SomeClass extends EventEmitter {
    constructor() {
        super();
    }
}

const obj = new SomeClass();

obj.on('init', () => {});
obj.on('input:start', () => {});
obj.on('input:end', () => {});

obj.off(/input:\w+/);

obj.emit('init');
obj.emit('input:start');    // ignored
obj.emit('input:end');      // ignored
```